### PR TITLE
chore: set up a `.iex.exs` [skip ci]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ npm-debug.log
 # direnv. https://direnv.net
 .env
 .envrc
+
+# .iex.local.exs. https://dev.to/joeljuca/introducing-iex-local-exs-2bfk
+.iex.local.exs

--- a/.iex.exs
+++ b/.iex.exs
@@ -1,0 +1,24 @@
+# Timesink
+alias Timesink.Application
+alias Timesink.Mailer
+alias Timesink.Repo
+
+# Timesink.Accounts
+alias Timesink.Accounts
+alias Timesink.Accounts.User
+
+# Timesink.Waitlist
+alias Timesink.Waitlist
+alias Timesink.Waitlist.Applicant
+
+# TimesinkWeb
+alias TimesinkWeb.Endpoint
+alias TimesinkWeb.Router
+alias TimesinkWeb.Temeletry
+
+alias TimesinkWeb.ErrorJSON
+
+alias TimesinkWeb.PageController
+
+# Local dot-iex file (user/environment-specific, Git-ignored)
+import_file_if_available(".iex.local.exs")


### PR DESCRIPTION
This is DX-related.

The `.iex.exs` file is loaded automatically whenever we launch an IEx session from the project – and an optional `.iex.local.exs` is loaded if it exists, allowing dev-specific local customizations (useful in tests, live debugging, etc.).